### PR TITLE
More robust /-command parsing

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ cachetools
 sentry-sdk
 anyio
 psycopg2-binary  # sigh
+mistletoe

--- a/requirements.in
+++ b/requirements.in
@@ -11,4 +11,4 @@ cachetools
 sentry-sdk
 anyio
 psycopg2-binary  # sigh
-mistletoe
+marko

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,8 @@ hyperframe==5.2.0         # via h2
 idna==2.9                 # via trio
 itsdangerous==1.1.0       # via quart
 jinja2==2.11.1            # via quart
+marko==0.7.1
 markupsafe==1.1.1         # via jinja2
-mistletoe==0.7.2
 outcome==1.0.1            # via trio
 pendulum==2.0.5
 priority==1.3.0           # via hypercorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ idna==2.9                 # via trio
 itsdangerous==1.1.0       # via quart
 jinja2==2.11.1            # via quart
 markupsafe==1.1.1         # via jinja2
+mistletoe==0.7.2
 outcome==1.0.1            # via trio
 pendulum==2.0.5
 priority==1.3.0           # via hypercorn

--- a/snekomatic/gh.py
+++ b/snekomatic/gh.py
@@ -361,8 +361,10 @@ class GithubApp:
                     command, event_type, payload, gh_client
                 )
             else:
-                # TODO: handle unrecognized commands
-                raise NotImplementedError
+                # We silently ignore unrecognized commands, because lines
+                # starting with / can happen randomly, e.g. because of
+                # absolute paths in warnings/traceback output.
+                pass
 
 
 _COMMENT_BODY_FIELDS_BY_EVENT_TYPE = {

--- a/snekomatic/gh.py
+++ b/snekomatic/gh.py
@@ -377,6 +377,7 @@ _COMMENT_BODY_FIELDS_BY_EVENT_TYPE = {
     "pull_request_review_comment": "comment.body",
 }
 
+
 def get_comment_body(event_type, payload):
     field = _COMMENT_BODY_FIELDS_BY_EVENT_TYPE.get(event_type)
     if field is None:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -30,6 +30,7 @@ importlib-metadata==1.5.0  # via pluggy, pytest
 itsdangerous==1.1.0       # via quart
 jinja2==2.11.1            # via quart
 markupsafe==1.1.1         # via jinja2
+mistletoe==0.7.2
 more-itertools==8.2.0     # via pytest
 outcome==1.0.1            # via trio
 packaging==20.1           # via pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -29,8 +29,8 @@ idna==2.9                 # via trio
 importlib-metadata==1.5.0  # via pluggy, pytest
 itsdangerous==1.1.0       # via quart
 jinja2==2.11.1            # via quart
+marko==0.7.1
 markupsafe==1.1.1         # via jinja2
-mistletoe==0.7.2
 more-itertools==8.2.0     # via pytest
 outcome==1.0.1            # via trio
 packaging==20.1           # via pytest

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -383,6 +383,11 @@ command_scenarios = [
         body="Looks good!\n/test-command\n\n\n  /test-command   hello  ",
         expected_commands=[["/test-command"], ["/test-command", "hello"]],
     ),
+    # unrecognized commands are silently ignored
+    CommandScenario(
+        body="/home/njs/hi\n /test-command ok\n/home/wgwz/code/trio",
+        expected_commands=[["/test-command", "ok"]],
+    ),
     CommandScenario(
         body=None,
         expected_commands=[],

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -379,6 +379,7 @@ command_scenarios = [
         body="/test-command hi",
         expected_commands=[["/test-command", "hi"]],
     ),
+    # Several commands with intermixed noise
     CommandScenario(
         body="Looks good!\n/test-command\n\n\n  /test-command   hello  ",
         expected_commands=[["/test-command"], ["/test-command", "hello"]],
@@ -388,9 +389,30 @@ command_scenarios = [
         body="/home/njs/hi\n /test-command ok\n/home/wgwz/code/trio",
         expected_commands=[["/test-command", "ok"]],
     ),
+    # We handle github's odd thing where body can be None instead of a string
     CommandScenario(
         body=None,
         expected_commands=[],
+    ),
+    # Check markdown handling
+    CommandScenario(
+        body="""
+/test-command 1
+
+```
+/test-command code-block
+```
+
+- /test-command in-list
+  /test-command also-in-list
+
+/test-command *emphasized*
+
+/test-command 2
+/test-command 3
+/test-command 4
+        """,
+        expected_commands=[["/test-command", str(i)] for i in [1, 2, 3, 4]]
     ),
 ]
 

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -406,7 +406,13 @@ command_scenarios = [
 - /test-command in-list
   /test-command also-in-list
 
-/test-command *emphasized*
+/test-command *with-markup*
+
+<!--
+
+/test-command in-comment
+
+-->
 
 /test-command 2
 /test-command 3

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -287,78 +287,92 @@ class WebhookScenario(object):
     expected_body = attr.ib()
     expected_reply_url = attr.ib()
     expected_reaction_url = attr.ib()
+
     def payload(self):
         return get_sample_data(self.test_data)
+
     def body(self):
         return get_comment_body(self.event_type, self.payload())
+
     def reply_url(self):
         return reply_url(self.event_type, self.payload())
+
     def reaction_url(self):
         return reaction_url(self.event_type, self.payload())
 
 
 # FIXME: other comment types
 webhook_scenarios = [
-    WebhookScenario(test_data="issue-created-webhook",
-             event_type="issues",
-             expected_body="This must be addressed immediately, if not before.",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/reactions",
-             ),
-    WebhookScenario(test_data="comment-existing-issue",
-             event_type="issue_comment",
-             expected_body="I agree with the original poster.",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/comments/544211719/reactions",
-             ),
-    WebhookScenario(test_data="comment-edited",
-             event_type="issue_comment",
-             expected_body="I agree with the original poster.\r\n\r\n[EDIT: on further thought, I disagree.]",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/comments/544211719/reactions",
-             ),
-    WebhookScenario(test_data="new-pr-created",
-             event_type="pull_request",
-             expected_body="",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/reactions",
-             ),
-    WebhookScenario(test_data="comment-existing-pr",
-             event_type="issue_comment",
-             expected_body="hello world :wave: ",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/comments/544211921/reactions",
-             ),
-    WebhookScenario(test_data="add-single-comment",
-             event_type="pull_request_review",
-             expected_body="",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/reviews/304238138/reactions",
-             ),
-    WebhookScenario(test_data="pr-review-comment",
-             event_type="pull_request_review_comment",
-             expected_body="This is just a standalone comment.",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/comments/336759908/replies",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/comments/336759908/reactions",
-             ),
-    WebhookScenario(test_data="full-pr-review",
-             event_type="pull_request_review",
-             expected_body="Truly a critical fix. However, maybe it needs more cowbell?",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/reviews/304238151/reactions",
-             ),
-    WebhookScenario(test_data="pr-review-comment-01",
-             event_type="pull_request_review_comment",
-             expected_body="This is part of a review.",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/comments/336759921/replies",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/comments/336759921/reactions",
-             ),
-    WebhookScenario(test_data="pr-review",
-             event_type="pull_request_review",
-             expected_body="Truly a critical fix. However, maybe it needs more cowbell?",
-             expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
-             expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/reviews/304238151/reactions",
-             ),
+    WebhookScenario(
+        test_data="issue-created-webhook",
+        event_type="issues",
+        expected_body="This must be addressed immediately, if not before.",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/reactions",
+    ),
+    WebhookScenario(
+        test_data="comment-existing-issue",
+        event_type="issue_comment",
+        expected_body="I agree with the original poster.",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/comments/544211719/reactions",
+    ),
+    WebhookScenario(
+        test_data="comment-edited",
+        event_type="issue_comment",
+        expected_body="I agree with the original poster.\r\n\r\n[EDIT: on further thought, I disagree.]",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/5/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/comments/544211719/reactions",
+    ),
+    WebhookScenario(
+        test_data="new-pr-created",
+        event_type="pull_request",
+        expected_body="",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/reactions",
+    ),
+    WebhookScenario(
+        test_data="comment-existing-pr",
+        event_type="issue_comment",
+        expected_body="hello world :wave: ",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/comments/544211921/reactions",
+    ),
+    WebhookScenario(
+        test_data="add-single-comment",
+        event_type="pull_request_review",
+        expected_body="",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/reviews/304238138/reactions",
+    ),
+    WebhookScenario(
+        test_data="pr-review-comment",
+        event_type="pull_request_review_comment",
+        expected_body="This is just a standalone comment.",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/comments/336759908/replies",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/comments/336759908/reactions",
+    ),
+    WebhookScenario(
+        test_data="full-pr-review",
+        event_type="pull_request_review",
+        expected_body="Truly a critical fix. However, maybe it needs more cowbell?",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/reviews/304238151/reactions",
+    ),
+    WebhookScenario(
+        test_data="pr-review-comment-01",
+        event_type="pull_request_review_comment",
+        expected_body="This is part of a review.",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/comments/336759921/replies",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/comments/336759921/reactions",
+    ),
+    WebhookScenario(
+        test_data="pr-review",
+        event_type="pull_request_review",
+        expected_body="Truly a critical fix. However, maybe it needs more cowbell?",
+        expected_reply_url="https://api.github.com/repos/njsmith-test-org/test-repo/issues/6/comments",
+        expected_reaction_url="https://api.github.com/repos/njsmith-test-org/test-repo/pulls/6/reviews/304238151/reactions",
+    ),
 ]
 
 
@@ -374,10 +388,10 @@ class CommandScenario:
     body = attr.ib()
     expected_commands = attr.ib()
 
+
 command_scenarios = [
     CommandScenario(
-        body="/test-command hi",
-        expected_commands=[["/test-command", "hi"]],
+        body="/test-command hi", expected_commands=[["/test-command", "hi"]]
     ),
     # Several commands with intermixed noise
     CommandScenario(
@@ -390,10 +404,7 @@ command_scenarios = [
         expected_commands=[["/test-command", "ok"]],
     ),
     # We handle github's odd thing where body can be None instead of a string
-    CommandScenario(
-        body=None,
-        expected_commands=[],
-    ),
+    CommandScenario(body=None, expected_commands=[]),
     # Check markdown handling
     CommandScenario(
         body="""
@@ -418,9 +429,10 @@ command_scenarios = [
 /test-command 3
 /test-command 4
         """,
-        expected_commands=[["/test-command", str(i)] for i in [1, 2, 3, 4]]
+        expected_commands=[["/test-command", str(i)] for i in [1, 2, 3, 4]],
     ),
 ]
+
 
 @pytest.mark.parametrize("scenario", command_scenarios)
 async def test_github_app_command_routing(autojump_clock, scenario):


### PR DESCRIPTION
- It turns out that lines starting with / happen randomly, e.g.
  because of people pasting absolute paths into comment boxes. So now we
  should ignore them instead of raising NotImplementedError like we used
  to.

- Switched to using a markdown parser to process text before searching
  for /-commands, so we ignore /-commands inside blockquotes, fenced
  code blocks, HTML comments, etc.

  This is probably silly overkill, but I had fun writing it, so hey.